### PR TITLE
add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 tpfancontrol-rs is a Linux TUI clone of troubadix's TPFanControl. It uses the sysfs interface exposed by the thinkpad-acpi kernel module to allow you to monitor and control the temperature and fan speeds of your Thinkpad.
 
-Build with `cargo build` and run with `cargo run`
+## Installation
 
-Install with `cargo install --git 'https://github.com/Arnavion/tpfancontrol-rs'`
+`$ cargo install --git 'https://github.com/Arnavion/tpfancontrol-rs'`
+
+## Usage
 
 The program reads a config file `/etc/tpfancontrol/config.toml` for the names of the temperature sensors and for the temperature-to-fan-level mapping. There is an example [`config.toml.example`](./config.toml.example) in this repository.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ tpfancontrol-rs is a Linux TUI clone of troubadix's TPFanControl. It uses the sy
 
 Build with `cargo build` and run with `cargo run`
 
+Install with `cargo install --git 'https://github.com/Arnavion/tpfancontrol-rs'`
+
 The program reads a config file `/etc/tpfancontrol/config.toml` for the names of the temperature sensors and for the temperature-to-fan-level mapping. There is an example `config.toml.example` in this repository.
 
 If run without superuser rights, the program does not have write access to the kernel interface, so the controls for modifying the fan speed will be locked.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Build with `cargo build` and run with `cargo run`
 
 Install with `cargo install --git 'https://github.com/Arnavion/tpfancontrol-rs'`
 
-The program reads a config file `/etc/tpfancontrol/config.toml` for the names of the temperature sensors and for the temperature-to-fan-level mapping. There is an example `config.toml.example` in this repository.
+The program reads a config file `/etc/tpfancontrol/config.toml` for the names of the temperature sensors and for the temperature-to-fan-level mapping. There is an example [`config.toml.example`](./config.toml.example) in this repository.
 
 If run without superuser rights, the program does not have write access to the kernel interface, so the controls for modifying the fan speed will be locked.
 


### PR DESCRIPTION
Would put the binary in `$HOME/.cargo/bin/tpfancontrol` automatically.